### PR TITLE
Add copier answers file to cache answers to questions.

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -12,11 +12,6 @@ project_name:
     {% if not project_name %} You must provide a name for the project. {% endif
     %}
 
-pip_name:
-  type: str
-  help: The Python package import name (for `import NAME` in Python code)
-  default: "{{ project_name|lower|replace('-', '_')|replace(' ', '_') }}"
-
 org:
   type: str
   help: What GitHub user is this project under?
@@ -28,6 +23,12 @@ url:
   type: str
   help: Provide/modify the url to your GitHub repository if needed.
   default: "https://github.com/{{org}}/{{project_name}}"
+
+
+pip_name:
+  type: str
+  help: The Python package import name (for `import NAME` in Python code)
+  default: "{{ project_name|lower|replace('-', '_')|replace(' ', '_') }}"
 
 full_name:
   type: str
@@ -69,7 +70,7 @@ backend:
 
 python_version_range:
   type: str
-  help: What Python version range does your project support?
+  help: What Python version range does your project support? (e.g. ">=3.8", ">=3.10, <3.12" [don't write the quotes])
   default: ">=3.8"
 
 typing:

--- a/project_template/{{_copier_conf.answers_file}}
+++ b/project_template/{{_copier_conf.answers_file}}
@@ -1,0 +1,2 @@
+# Changes here will be overwritten by Copier
+{{ _copier_answers|to_nice_yaml -}}


### PR DESCRIPTION
This should allow for projects to be re-updated in-place, where answers will default to those already given last time the template was used. See [here](https://copier.readthedocs.io/en/stable/configuring/#the-copier-answersyml-file) for more info.