### PR TITLE
Dynamic versioning for setuptools

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -78,5 +78,12 @@ typing:
   help: Would you like to use static type checking? (This configures mypy.)
   choices:
     "No": no_typing
-    "Basic type checking (type annotations not required)": loose
-    "Full type checking (type annotations required)": strict
+    "Basic type checking (type annotations not required).": loose
+    "Full type checking (type annotations required).": strict
+
+coc:
+  type: str
+  help: We provide a basic Code of Conduct that can be modified to suit the needs of your project. Would you like to use this, or write your own?
+  choices:
+    "I'll use/modify the basic Code of Conduct.": our_coc
+    "I'll write my own Code of Conduct.": their_coc

--- a/copier.yml
+++ b/copier.yml
@@ -81,9 +81,3 @@ typing:
     "Basic type checking (type annotations not required).": loose
     "Full type checking (type annotations required).": strict
 
-coc:
-  type: str
-  help: We provide a basic Code of Conduct that can be modified to suit the needs of your project. Would you like to use this, or write your own?
-  choices:
-    "I'll use/modify the basic Code of Conduct.": our_coc
-    "I'll write my own Code of Conduct.": their_coc

--- a/project_template/pyproject.toml
+++ b/project_template/pyproject.toml
@@ -62,9 +62,6 @@ dev = ["pytest", "pytest-cov"]
 {%- else %}
 [project]
 name = "{{ project_name }}"
-{%- if backend == "setuptools" %}
-version = "0.1.0"  # need to also update version in src/{{ python_name }}/__init__.py
-{%- endif %}
 authors = [
   { name = "{{ full_name }}", email = "{{ email }}" },
 ]
@@ -98,11 +95,13 @@ classifiers = [
   "Typing :: Typed",
 {%- endif %}
 ]
-{% if backend == "hatch" -%}
 dynamic = ["version"]  # version is set in src/{{ python_name }}/__init__.py
-{%- endif %}
 dependencies = []
 
+{%- if backend == "setuptools" %}
+[tool.setuptools.dynamic]
+version = {attr = "{{ python_name }}.__version__"}  # version taken from src/{{ python_name }}/__init__.py
+{%- endif %}
 [project.optional-dependencies]
 test = [
   "pytest >=6",


### PR DESCRIPTION
Makes the project version dynamic, and grabs it from `__version__` in `__init__.py`, giving consistent behaviour between hatch and setuptools.

Thanks @yongrenjie for suggesting this in #12, worked basically out of the box!