### PR TITLE
Check regex for author email

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -43,8 +43,10 @@ email:
   help: What's their email?
   placeholder: me@email.com
   validator: >-
-    {% if not email %} You must provide an email (possibly yours) to place in
-    your config files, as required by PyPI. {% endif %}
+    {% if not author_email or not (author_email | regex_search('^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$')) %}
+    author_email must be a valid email address.
+    You must provide a valid email to place in
+    your config files. {% endif %}
 
 project_short_description:
   type: str
@@ -77,7 +79,7 @@ typing:
   type: str
   help: Would you like to use static type checking? (This configures mypy.)
   choices:
-    "No": no_typing
+    "No/I'll add it myself.": no_typing
     "Basic type checking (type annotations not required).": loose
     "Full type checking (type annotations required).": strict
 

--- a/copier.yml
+++ b/copier.yml
@@ -43,10 +43,10 @@ email:
   help: What's their email?
   placeholder: me@email.com
   validator: >-
-    {% if not author_email or not (author_email | regex_search('^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$')) %}
-    author_email must be a valid email address.
+    {% if not (email | regex_search('^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$')) %}
     You must provide a valid email to place in
-    your config files. {% endif %}
+    your config files.
+    {% endif %}
 
 project_short_description:
   type: str


### PR DESCRIPTION
Stole some nice regex from a different copier template:

https://github.com/jupyterlab/extension-template/blob/2879c2b70e455d7afbb9eb80e87bb475524e2b28/copier.yml#L25-L34

(except we will not allow blank emails!)

Resolves #9.