### PR TITLE
Ask for minimum supported Python version instead of a range + trim down pre-commit config

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -70,16 +70,20 @@ backend:
     "Hatchling   - As above, but can also interface with hatch. (recommended)": hatch
     "Poetry      - All-in-one solution to development.": poetry
 
-python_version_range:
+min_python_version:
   type: str
-  help: What Python version range does your project support? (e.g. ">=3.8", ">=3.10, <3.12" [don't write the quotes])
-  default: ">=3.8"
+  help: What is the minimum version of Python your project will support? (Defaults to minimum supported by NumPy)
+  default: "3.10"
+  validator: >-
+    {% if not (min_python_version | regex_search('[3][.][0-9]+')) %}
+    Please supply a valid Python 3 version (e.g. 3.11).
+    {% endif %}
 
 typing:
   type: str
   help: Would you like to use static type checking? (This configures mypy.)
   choices:
-    "No/I'll add it myself.": no_typing
+    "No/I'll configure it myself.": no_typing
     "Basic type checking (type annotations not required).": loose
     "Full type checking (type annotations required).": strict
 

--- a/project_template/.github/workflows/ci.yml
+++ b/project_template/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.12]     
-        runs-on: [ubuntu-latest]  # can be extended to other OSes, e.g. macOS/Windows if needed
-        
+        python-version: [{{ min_python_version }}, 3.12]  # test oldest and latest supported versions
+        runs-on: [ubuntu-latest]  # can be extended to other OSes, e.g. [ubuntu-latest, macos-latest]
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/project_template/.pre-commit-config.yaml
+++ b/project_template/.pre-commit-config.yaml
@@ -19,13 +19,6 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.0.3"
-    hooks:
-      - id: prettier
-        types_or: [yaml, markdown, html, css, scss, javascript, json]
-        args: [--prose-wrap=always]
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.2.0"
     hooks:
@@ -38,16 +31,11 @@ repos:
 
 {% if typing != "no_typing" %}
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.5.1"
+    rev: "v1.8.0"
     hooks:
       - id: mypy
-        files: src|tests
+        files: src
         args: []
         additional_dependencies:
           - pytest
-{% endif %}
-
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: "v0.9.0.5"
-    hooks:
-      - id: shellcheck
+{%- endif %}

--- a/project_template/CONTRIBUTING.md
+++ b/project_template/CONTRIBUTING.md
@@ -7,21 +7,18 @@ description of best practices for developing scientific packages.
 
 You can set up a development environment by running:
 
-{% if backend == "poetry" %}
-
+{%- if backend == "poetry" %}
 ```zsh
 poetry install
 ```
-
-{% else %}
+{%- else %}
 
 ```zsh
 python3 -m venv venv          # create a virtualenv called venv
-source ./.venv/bin/activate   # now `python` points to the virtualenv python
+source ./venv/bin/activate   # now `python` points to the virtualenv python
 pip install -v -e ".[dev]"    # -v for verbose, -e for editable, [dev] for dev dependencies
 ```
-
-{% endif %}
+{%- endif %}
 
 # Post setup
 

--- a/project_template/pyproject.toml
+++ b/project_template/pyproject.toml
@@ -10,7 +10,6 @@ requires = ["poetry_core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 {%- endif %}
 
-
 {%- if backend == "poetry" %}
 [tool.poetry]
 name = "{{ project_name }}"
@@ -44,7 +43,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = {{ python_version_range }}
+python = ">={{ min_python_version }}"
 
 pytest = { version = ">=6", optional = true }
 pytest-cov = { version = ">=3", optional = true }
@@ -57,8 +56,6 @@ pytest-cov = ">= 3"
 test = ["pytest", "pytest-cov"]
 dev = ["pytest", "pytest-cov"]
 
-
-
 {%- else %}
 [project]
 name = "{{ project_name }}"
@@ -67,7 +64,7 @@ authors = [
 ]
 description = "{{ project_short_description }}"
 readme = "README.md"
-requires-python = "{{ python_version_range }}"
+requires-python = ">={{ min_python_version }}"
 classifiers = [
   "Development Status :: 1 - Planning",
   "Intended Audience :: Science/Research",
@@ -85,7 +82,6 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -100,7 +96,7 @@ dependencies = []
 
 {%- if backend == "setuptools" %}
 [tool.setuptools.dynamic]
-version = {attr = "{{ python_name }}.__version__"}  # version taken from src/{{ python_name }}/__init__.py
+version = {attr = "{{ python_name }}.__version__"}
 {%- endif %}
 [project.optional-dependencies]
 test = [
@@ -151,7 +147,7 @@ port.exclude_lines = [
 {% if typing != "no_typing" -%}
 [tool.mypy]
 files = ["src", "tests"]
-python_version = "3.8"
+python_version = "{{ min_python_version }}"
 show_error_codes = true
 warn_unreachable = true
 disallow_untyped_defs = false

--- a/project_template/src/{{python_name}}/__init__.py
+++ b/project_template/src/{{python_name}}/__init__.py
@@ -3,6 +3,5 @@
 """
 from __future__ import annotations
 
-
 __all__ = ("__version__",)
 __version__ = "0.1.0"


### PR DESCRIPTION
It's a bit tricky to meaningfully parse a version range and extract the minimum supported version for CI and linting/checking purposes. This PR replaces the version range question with just the minimum Python version, and will by default support Python versions equal to or greater than this version. A nice perk of this is the simple extraction of the version number to run mypy and test CI with.

This PR also removes some of the pre-commit hooks that are not specific to a Python project. I realized myself that I wouldn't necessarily want my markdown/yaml files to be prose-wrapped or things like this in my Python project.