### PR TITLE
ci: add CI for template instantiation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+name: Test Template Instance
+
+on:
+  pull_request:
+    branches:
+      - main
+
+
+jobs:
+  Creation:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+      - name: Install Dependencies
+        run: |
+          pip install copier pre-commit
+      - name: Create copy
+        run: |
+          copier copy \
+            -d project_name=test \
+            -d org=gh_actions \
+            -d full_name=gh_actions \
+            -d email=foo@example.com \
+            -d license=BSD \
+            -d backend=setuptools \
+            -d typing=strict \
+            -d coc=our_coc \
+            project_template instance
+      - name: linting
+        run: |
+          cd instance
+          pre-commit run --all
+      - name: project-install
+        run: pip install .


### PR DESCRIPTION
This PR adds CI to create an instance of the template and run pre-commits on it.  Hopefully this can help with #14

I believe this counts as fixing #4, depending on what you want to see in the CI.