### PR TITLE
update versioning to rely on pyproject.toml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
           mkdir my-project
           copier copy \
             -d project_name=test \
-            -d project_short_description=A great package. \
+            -d project_short_description="A great package." \
             -d url=https://github.com/gh_actions/test \
             -d min_python_version=3.10 \
             -d org=gh_actions \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,12 @@ on:
 
 jobs:
   test-project-creation:
+    name: Test project creation with    ${{ matrix.backend }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      matrix:
+        backend: [setuptools, hatch, poetry]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -20,7 +23,6 @@ jobs:
           python-version: "3.x"
       - name: Install Dependencies
         run: |
-          set -eux
           pip install copier pre-commit
       - name: Create new project
         run: |
@@ -42,7 +44,9 @@ jobs:
             . my-project
       - name: Check generated project passes pre-commit and installs with pip
         run: |
-          cd my-project 
+          cd my-project
+          git config --global user.email "foo@example.com"
+          git config --global user.name "gh_actions"
           git init
           git commit -am "Initial commit"
           cat .pre-commit-config.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,15 +12,16 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v3
+     - uses: actions/checkout@v4
         with:
-          python-version: "3.9"
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
       - name: Install Dependencies
         run: |
           pip install copier pre-commit
-      - name: Create copy
+      - name: Create new project
         run: |
           copier copy \
             -d project_name=test \
@@ -35,6 +36,6 @@ jobs:
       - name: linting
         run: |
           cd instance
-          pre-commit run --all
-      - name: project-install
-        run: pip install .
+          pre-commit run --all-files
+      - name: Check project installs (with -e)
+        run: pip install -e .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
           copier copy \
             -d project_name=test \
             -d project_short_description="A great package." \
+            -d python_name=test \
             -d url=https://github.com/gh_actions/test \
             -d min_python_version=3.10 \
             -d org=gh_actions \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-     - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,8 @@ jobs:
           git config --global user.email "foo@example.com"
           git config --global user.name "gh_actions"
           git init
-          git commit -am "Initial commit"
+          git add .
+          git commit -m "Initial commit"
           cat .pre-commit-config.yaml
           pre-commit run --all-files
           pip install -e .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,11 +20,16 @@ jobs:
           python-version: "3.x"
       - name: Install Dependencies
         run: |
+          set -eux
           pip install copier pre-commit
       - name: Create new project
         run: |
+          mkdir my-project
           copier copy \
             -d project_name=test \
+            -d project_short_description=A great package. \
+            -d url=https://github.com/gh_actions/test \
+            -d min_python_version=3.10 \
             -d org=gh_actions \
             -d full_name=gh_actions \
             -d email=foo@example.com \
@@ -32,10 +37,12 @@ jobs:
             -d backend=setuptools \
             -d typing=strict \
             -d coc=our_coc \
-            . instance
-      - name: linting
+            --vcs-ref HEAD \
+            . my-project
+      - name: Check generated project passes pre-commit
         run: |
-          cd instance
+          cd my-project 
+          git init
           cat .pre-commit-config.yaml
           pre-commit run --all-files
       - name: Check project installs (with -e)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
             -d backend=setuptools \
             -d typing=strict \
             -d coc=our_coc \
-            project_template instance
+            . instance
       - name: linting
         run: |
           cd instance

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 
 jobs:
-  Creation:
+  test-project-creation:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -40,11 +40,11 @@ jobs:
             -d coc=our_coc \
             --vcs-ref HEAD \
             . my-project
-      - name: Check generated project passes pre-commit
+      - name: Check generated project passes pre-commit and installs with pip
         run: |
           cd my-project 
           git init
+          git commit -am "Initial commit"
           cat .pre-commit-config.yaml
           pre-commit run --all-files
-      - name: Check project installs (with -e)
-        run: pip install -e .
+          pip install -e .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       - name: linting
         run: |
           cd instance
-          cat .pre-commit-config
+          cat .pre-commit-config.yaml
           pre-commit run --all-files
       - name: Check project installs (with -e)
         run: pip install -e .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
       - name: linting
         run: |
           cd instance
+          cat .pre-commit-config
           pre-commit run --all-files
       - name: Check project installs (with -e)
         run: pip install -e .

--- a/project_template/CODE_OF_CONDUCT.md
+++ b/project_template/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ Examples of unacceptable behaviour by participants include:
  professional setting
 
 <!-- 
-Modify the following sections to the needs of your project. 
+Modify the following sections to the needs of your project.
 
 ## Our Responsibilities
 
@@ -49,4 +49,3 @@ Modify the following sections to the needs of your project.
 This Code of Conduct is adapted from the [Turing Data Stories Code of Conduct](https://github.com/alan-turing-institute/TuringDataStories/blob/main/CODE_OF_CONDUCT.md) which is based on the [scona project Code of Conduct](https://github.com/WhitakerLab/scona/blob/master/CODE_OF_CONDUCT.md) 
 and the [Contributor Covenant](https://www.contributor-covenant.org), version [1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)
 {%- endif -%}
-

--- a/project_template/pyproject.toml
+++ b/project_template/pyproject.toml
@@ -59,6 +59,7 @@ dev = ["pytest", "pytest-cov"]
 {%- else %}
 [project]
 name = "{{ project_name }}"
+version = "0.1.0"
 authors = [
   { name = "{{ full_name }}", email = "{{ email }}" },
 ]
@@ -91,13 +92,8 @@ classifiers = [
   "Typing :: Typed",
 {%- endif %}
 ]
-dynamic = ["version"]  # version is set in src/{{ python_name }}/__init__.py
 dependencies = []
 
-{%- if backend == "setuptools" %}
-[tool.setuptools.dynamic]
-version = {attr = "{{ python_name }}.__version__"}
-{%- endif %}
 [project.optional-dependencies]
 test = [
   "pytest >=6",
@@ -116,7 +112,6 @@ Changelog = "{{ url }}/releases"
 
 {%- if backend == "hatch" %}
 [tool.hatch]
-version.path = "src/{{ python_name  }}/__init__.py"
 envs.default.dependencies = [
   "pytest",
   "pytest-cov",

--- a/project_template/src/{{python_name}}/__init__.py
+++ b/project_template/src/{{python_name}}/__init__.py
@@ -2,6 +2,7 @@
 {{ project_name }}: {{ project_short_description }}
 """
 from __future__ import annotations
+
 from importlib.metadata import version
 
 __all__ = ("__version__",)

--- a/project_template/src/{{python_name}}/__init__.py
+++ b/project_template/src/{{python_name}}/__init__.py
@@ -2,6 +2,7 @@
 {{ project_name }}: {{ project_short_description }}
 """
 from __future__ import annotations
+from importlib.metadata import version
 
 __all__ = ("__version__",)
-__version__ = "0.1.0"
+__version__ = version(__name__) 


### PR DESCRIPTION
This changes the dynamic versioning scheme, which relied on ``__version__`` being defined in `pyproject.toml`, in favor of a static scheme that only looks in `pyproject.toml`, using `importlib.metadata.version(__name__)` to define `__version__` instead. Picks up the right version on the setuptools backend when tested locally.

Thanks for the idea @jack89roberts!