### PR TITLE
:bug: Install pre-commit in update action

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -21,7 +21,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-
+      - name: Install pre-commit
+        run: pip install pre-commit
       - name: Update pre-commit hooks
         run: |
           cd project_template


### PR DESCRIPTION
Should be a quick fix for the update action, which I noticed had failed. You could consider having `pre-commit` as one of the Python dependencies included in the template as well/instead of this (don't think it is currently)?